### PR TITLE
add json tags to PackageInfo struct and tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bluet/syspkg
 
-go 1.23
+go 1.23.0
 
 require github.com/urfave/cli/v2 v2.27.7 // direct
 

--- a/manager/packageinfo.go
+++ b/manager/packageinfo.go
@@ -52,38 +52,38 @@ const (
 //	unknown:     Version="", NewVersion may contain repo_version
 type PackageInfo struct {
 	// Name is the package name.
-	Name string
+	Name string `json:"name"`
 
 	// Version is the currently installed version of the package.
 	// Empty if package is not installed (Status=available).
 	// Contains removed version for Delete operations.
-	Version string
+	Version string `json:"version,omitempty"`
 
 	// NewVersion is the latest available version from repositories.
 	// Used for available versions in Find operations and upgrade targets.
 	// Empty for ListInstalled operations.
 	// Same as Version for Install operations.
-	NewVersion string
+	NewVersion string `json:"new_version,omitempty"`
 
 	// Status indicates the current PackageStatus of the package.
 	// See PackageStatus constants for detailed descriptions.
-	Status PackageStatus
+	Status PackageStatus `json:"status"`
 
 	// Category is the category/section the package belongs to.
 	// Examples: "utilities", "development", "web", "jammy", "main"
 	// May represent repository sections or package categories depending on package manager.
-	Category string
+	Category string `json:"category,omitempty"`
 
 	// Arch is the architecture the package is built for.
 	// Examples: "amd64", "arm64", "i386", "all"
 	// Empty if architecture is not specified or not applicable.
-	Arch string
+	Arch string `json:"arch,omitempty"`
 
 	// PackageManager is the name of the package manager used to manage this package.
 	// Examples: "apt", "yum", "dnf", "snap", "flatpak"
-	PackageManager string
+	PackageManager string `json:"package_manager"`
 
 	// AdditionalData is a map of key-value pairs for additional package-specific metadata.
 	// Used for package manager specific information that doesn't fit standard fields.
-	AdditionalData map[string]string
+	AdditionalData map[string]string `json:"additional_data,omitempty"`
 }

--- a/manager/packageinfo_test.go
+++ b/manager/packageinfo_test.go
@@ -1,0 +1,41 @@
+package manager
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestPackageInfoJsonTag(t *testing.T) {
+	// Populate all fields to ensure they are present in the JSON output.
+	testPackage := PackageInfo{
+		Name:           "test-pkg",
+		Version:        "1.0.0",
+		NewVersion:     "1.1.0",
+		Status:         PackageStatusUpgradable,
+		Category:       "test-cat",
+		Arch:           "amd64",
+		PackageManager: "test-pm",
+		AdditionalData: map[string]string{"foo": "bar"},
+	}
+
+	jsonAsByte, err := json.Marshal(testPackage)
+	if err != nil {
+		t.Fatalf("json.Marshal failed: %v", err)
+	}
+
+	var data map[string]interface{}
+	if err := json.Unmarshal(jsonAsByte, &data); err != nil {
+		t.Fatalf("json.Unmarshal failed: %v", err)
+	}
+
+	expectedTags := []string{"name", "version", "new_version", "status", "category", "arch", "package_manager", "additional_data"}
+	for _, tag := range expectedTags {
+		if _, ok := data[tag]; !ok {
+			t.Errorf("Expected tag '%s' not found in JSON output: %s", tag, string(jsonAsByte))
+		}
+	}
+
+	if len(data) != len(expectedTags) {
+		t.Errorf("Expected %d tags, but got %d. JSON: %s", len(expectedTags), len(data), string(jsonAsByte))
+	}
+}


### PR DESCRIPTION
json should have low case, underscore separated names.
Add tests that verify that the tags have been used
Fix a missing `.0` in the go version, that prevented successful download of toolchain

Changelog: added
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add JSON tags to `PackageInfo` struct and tests to verify serialization, and fix Go version in `go.mod`.
> 
>   - **Struct Changes**:
>     - Add JSON tags to `PackageInfo` struct fields in `packageinfo.go` for proper serialization.
>   - **Testing**:
>     - Add `TestPackageInfoJsonTag` in `packageinfo_test.go` to verify JSON tags are applied.
>   - **Misc**:
>     - Fix Go version in `go.mod` from `1.23` to `1.23.0`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=bluet%2Fsyspkg&utm_source=github&utm_medium=referral)<sup> for 0874811c0f7b15375f140c5ff30e0176021e9c60. You can [customize](https://app.ellipsis.dev/bluet/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Standardized JSON field names for package information (consistent snake_case) and made several fields optional to reduce noise in responses.

* **Chores**
  * Updated Go toolchain version declaration.

* **Tests**
  * Added JSON serialization tests to validate field names and presence for package information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->